### PR TITLE
Updates repo to the current set of Indeed repo standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [opensource@indeed.com](mailto:opensource@indeed.com). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-pache License
+Apache License
 Version 2.0, January 2004
 http://www.apache.org/licenses/
 
@@ -189,4 +189,3 @@ third-party archives.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/OSSMETADATA
+++ b/OSSMETADATA
@@ -1,0 +1,1 @@
+osslifecycle=active

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ See the examples in [our storybook](https://indeedeng.github.io/react-link-to-in
 This project is governed by the [Contributor Covenant v 1.4.1](CODE_OF_CONDUCT.md)
 
 ## License
-This project uses the [Apache 2.0](LICENSE.txt) license.
+This project uses the [Apache 2.0](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# react-link-to-inbox ![react-link-to-inbox travis build status](https://travis-ci.org/indeedeng/react-link-to-inbox.svg) ![react-link-to-inbox appveyor build status](https://ci.appveyor.com/api/projects/status/github/doug-wade/react-link-to-inbox?branch=master&svg=true) ![react-link-to-inbox codecov status](https://img.shields.io/codecov/c/github/indeedeng/react-link-to-inbox.svg)
+# react-link-to-inbox ![react-link-to-inbox travis build status](https://travis-ci.org/indeedeng/react-link-to-inbox.svg) ![react-link-to-inbox appveyor build status](https://ci.appveyor.com/api/projects/status/github/doug-wade/react-link-to-inbox?branch=master&svg=true) ![react-link-to-inbox codecov status](https://img.shields.io/codecov/c/github/indeedeng/react-link-to-inbox.svg) ![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/indeedeng/react-link-to-inbox.svg)
+
 
 A thin react wrapper around [link-to-inbox](http://npmjs.com/package/link-to-inbox)
 
@@ -72,3 +73,9 @@ export default (email) => {
 ## Documentation
 
 See the examples in [our storybook](https://indeedeng.github.io/react-link-to-inbox/).
+
+## Code of Conduct
+This project is governed by the [Contributor Covenant v 1.4.1](CODE_OF_CONDUCT.md)
+
+## License
+This project uses the [Apache 2.0](LICENSE.txt) license.


### PR DESCRIPTION
This pull request updates the django-proctor repo to the current set repo standards for Indeed.

+ Adds a Code of Conduct
+ Adds the OSSMETADATA File
+ Updates the README to add the OSS Lifecycle shield, License information, and the Code of Conduct
+ Fixes a typo in the Apache license file (the first A in Apache was cut off)

Please confirm the OSSMETADATA file accurately reflects the project's current status (Active).